### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url='https://github.com/uranusjr/pystandardpaths',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=list(requirements),
     license='BSD',
     zip_safe=False,
     keywords='qstandardpaths',


### PR DESCRIPTION
fix problem with: python3 setup.py build
error in pystandardpaths setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed